### PR TITLE
Deprecation warning fix + `LOG_CHANNEL` optional feature + bug fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,8 @@ async def auto():
 @bot.command()
 async def ump(ctx):
     channel = bot.get_channel(ctx.channel.id)
-    async for command in channel.slash_commands():
+    application_commands = await channel.application_commands()
+    for command in application_commands:
         if command.name == "bump":
             await command(channel)
             await asyncio.sleep(60)

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from random import randint
 bot = Bot(command_prefix="b", self_bot=True, chunk_guilds_at_startup=False)
 
 TOKEN = "YOUR TOKEN"
-LOG_CHANNEL = "YOUR LOG CHANNEL" # Put the channel id without quotation marks
+LOG_CHANNEL = "YOUR LOG CHANNEL" # OPTIONAL - Put the channel id without quotation marks
 CHANNEL_IDS = []
 
 @bot.event
@@ -18,8 +18,9 @@ async def auto():
         channels = CHANNEL_IDS
         for channel_id in channels:
             if channel := bot.get_channel(channel_id):
-                log_channel = bot.get_channel(LOG_CHANNEL)
-                await log_channel.send(f"```Sent bump command!\nChannel ID: {channel_id}```")
+                if LOG_CHANNEL:
+                    log_channel = bot.get_channel(LOG_CHANNEL)
+                    await log_channel.send(f"```Sent bump command!\nChannel ID: {channel_id}```")
                 await channel.send("bump")
                 await asyncio.sleep(randint(1800, 1820))  # wait after each message
         await asyncio.sleep(randint(7200, 7220))  # wait after each round of messages

--- a/main.py
+++ b/main.py
@@ -30,7 +30,10 @@ async def ump(ctx):
     channel = bot.get_channel(ctx.channel.id)
     application_commands = await channel.application_commands()
     for command in application_commands:
-        if command.name == "bump":
+        if command.name == "bump" and (
+            command.application_id == 302050872383242240
+            or command.id == 1252409457757913260
+        ):
             await command(channel)
             await asyncio.sleep(60)
 

--- a/main.py
+++ b/main.py
@@ -17,8 +17,7 @@ async def auto():
     while True:
         channels = CHANNEL_IDS
         for channel_id in channels:
-            channel = bot.get_channel(channel_id)
-            if channel:
+            if channel := bot.get_channel(channel_id):
                 log_channel = bot.get_channel(LOG_CHANNEL)
                 await log_channel.send(f"```Sent bump command!\nChannel ID: {channel_id}```")
                 await channel.send("bump")


### PR DESCRIPTION
Fixed up the deprecation warning, and made the `LOG_CHANNEL` an optional feature. Also added a walrus operator (`:=`) to simplify the assignment -> conditional.

There was a major issue where you can have multiple bots that have a `/bump` command it would trigger the first one found. Instead you can use the specific `id`/`application_id` found in the attributes of `discord.commands.SlashCommand`.